### PR TITLE
Fix flash of full path at start of animation

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -301,7 +301,7 @@ if(d.properties.hasfare) { //transition marker to show full taxi
 
 function transition(path) {
 
-    g.selectAll
+    path.attr("stroke-dasharray", "0," + path.node().getTotalLength());
 
     path.transition()
     .duration(function(d){


### PR DESCRIPTION
When a taxi picks up a passenger, the entire eventual path is shown for a frame. Added an initial `stroke-dasharray` value to avoid this
